### PR TITLE
Settings Menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # Imgui
 imgui.ini
+#Game config files
+**/[Cc]onfig/*.*
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/GameBox/GameBox/Game.cpp
+++ b/GameBox/GameBox/Game.cpp
@@ -2,11 +2,13 @@
 #include <SFML\Graphics.hpp>
 #include "state/GameState.h"
 #include "state/MainMenuState.h"
+#include "state/SettingsMenuState.h"
 
 #include "imgui/imgui.h"
 #include "imgui/imgui-SFML.h"
 
 Game::Game() : m_window(sf::VideoMode(1600, 800), "Gamebox setup test") {
+	m_settings.Load();
 	m_font.loadFromFile("../Resources/Arcon-Regular.otf");
 	m_currentState = new MainMenuState(this);
 	// Set up ImGui
@@ -14,6 +16,8 @@ Game::Game() : m_window(sf::VideoMode(1600, 800), "Gamebox setup test") {
 }
 
 Game::~Game() {
+	m_settings.Save();
+
 	if (m_currentState) {
 		delete m_currentState;
 	}
@@ -61,6 +65,9 @@ void Game::SetState(States::ID id) {
 	case States::Game:
 		m_nextState = new GameState(this);
 		break;
+	case States::SettingsMenu:
+		m_nextState = new SettingsMenuState(this);
+		break;
 	default:
 		break;
 	}
@@ -72,6 +79,14 @@ sf::RenderWindow* Game::getWindow() {
 
 sf::Font& Game::GetFont() {
 	return m_font;
+}
+
+const Settings& Game::GetSettingsConst() const {
+	return m_settings;
+}
+
+Settings& Game::GetSettings() {
+	return m_settings;
 }
 
 void Game::ApplyNextState() {

--- a/GameBox/GameBox/Game.h
+++ b/GameBox/GameBox/Game.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "state/State.h"
+#include "Settings.h"
 
 class Game {
 public:
@@ -13,6 +14,10 @@ public:
 
 	sf::RenderWindow* getWindow();
 	sf::Font& GetFont();
+
+	const Settings& GetSettingsConst() const;
+	Settings& GetSettings();
+
 private:
 	void ApplyNextState();
 	sf::RenderWindow m_window;
@@ -22,4 +27,6 @@ private:
 
 	State* m_currentState = nullptr;
 	State* m_nextState = nullptr;
+
+	Settings m_settings;
 };

--- a/GameBox/GameBox/GameBox.vcxproj
+++ b/GameBox/GameBox/GameBox.vcxproj
@@ -90,9 +90,10 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(solutionDir)GameBox\thirdparty;$(SolutionDir)../SFML/Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,9 +110,10 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(solutionDir)GameBox\thirdparty;$(SolutionDir)..\entityx\include;$(SolutionDir)..\SFML\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -129,9 +131,10 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(solutionDir)GameBox\thirdparty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -152,9 +155,10 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(solutionDir)GameBox\thirdparty;$(SolutionDir)..\entityx\include;$(SolutionDir)..\SFML\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -176,6 +180,7 @@
     <ClCompile Include="ECS\Systems\SpriteRenderSystem.cpp" />
     <ClCompile Include="ECS\Systems\TextSystem.cpp" />
     <ClCompile Include="Game.cpp" />
+    <ClCompile Include="Settings.cpp" />
     <ClCompile Include="state\Common UI\Button.cpp" />
     <ClCompile Include="state\GameState.cpp" />
     <ClCompile Include="main.cpp" />
@@ -185,6 +190,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="state\SettingsMenuState.cpp" />
     <ClCompile Include="state\State.cpp" />
     <ClCompile Include="TextureHandler.cpp" />
     <ClCompile Include="thirdparty\imgui\imgui-SFML.cpp" />
@@ -211,6 +217,8 @@
     <ClInclude Include="state\Common UI\Button.h" />
     <ClInclude Include="state\GameState.h" />
     <ClInclude Include="state\MainMenuState.h" />
+    <ClInclude Include="Settings.h" />
+    <ClInclude Include="state\SettingsMenuState.h" />
     <ClInclude Include="state\State.h" />
     <ClInclude Include="TextureHandler.h" />
     <ClInclude Include="thirdparty\imgui\imconfig-SFML.h" />

--- a/GameBox/GameBox/GameBox.vcxproj.filters
+++ b/GameBox/GameBox/GameBox.vcxproj.filters
@@ -84,6 +84,12 @@
     <ClCompile Include="thirdparty\imgui\imgui-SFML.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="state\SettingsMenuState.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Settings.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="state\GameState.h">
@@ -165,6 +171,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="thirdparty\imgui\imstb_truetype.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="state\SettingsMenuState.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/GameBox/GameBox/Settings.cpp
+++ b/GameBox/GameBox/Settings.cpp
@@ -1,11 +1,35 @@
 #include "Settings.h"
 #include <fstream>
+#include <random>
 
 // SAVE_SETTING is a macro that writes a setting and its value to a stream.
 // It takes the name of the setting (varName) and a stream (stream) as arguments.
 // The macro writes the setting's display name (varName_disp), followed by a colon and the setting's value (varName).
 // It also adds a newline character at the end.
 #define SAVE_SETTING(varName, stream) stream << varName##_##disp << ":" << varName << "\n"
+
+static const int NUM_RANDOM_USERNAMES = 20;
+std::string m_usernames[NUM_RANDOM_USERNAMES] = {
+	"ObamaDoge",
+	"PepeGates",
+	"JobsGonnaTellMyKids",
+	"TrollfaceBieber",
+	"ForeverAloneJackson",
+	"YOLOMadonna",
+	"SpongeGarLennon",
+	"ThisIsFineMouseTrump",
+	"PeanutButterJellyTimeLopez",
+	"GrumpyCatPfeiffer",
+	"PhilosoraptorDarwin",
+	"CondescendingEinstein",
+	"OneDoesNotSimplyShakespeare",
+	"StonksGates",
+	"BadLuckGalileo",
+	"MemeLordMaximusDaVinci",
+	"HarambeNapoleon",
+	"AristotleDatBoi",
+	"MockingSpongeBobPlato"
+};
 
 Settings::Settings() {
 
@@ -60,7 +84,11 @@ void Settings::Load() {
 	}
 }
 
-const std::string& Settings::GetPlayerName() const {
+const std::string& Settings::GetPlayerName() {
+	if (m_playerName == "") {
+		RandomizePlayerName();
+	}
+
 	return m_playerName;
 }
 
@@ -77,4 +105,16 @@ std::filesystem::path Settings::GetSettingsFilePath() {
 	auto path = G_CONFIG_PATH.string() + "/" + G_SETTINGS_FILENAME.string();
 	// Return the full path to the settings file.
 	return path;
+}
+
+void Settings::RandomizePlayerName() {
+	// Initialize a random number generator
+	std::random_device rd;
+	std::mt19937 gen(rd());
+
+	// Randomly select a name from the list
+	std::uniform_int_distribution<> name_dist(0, NUM_RANDOM_USERNAMES - 1);
+	int name_idx = name_dist(gen);
+	m_playerName = m_usernames[name_idx];
+	int i = 0;
 }

--- a/GameBox/GameBox/Settings.cpp
+++ b/GameBox/GameBox/Settings.cpp
@@ -1,0 +1,80 @@
+#include "Settings.h"
+#include <fstream>
+
+// SAVE_SETTING is a macro that writes a setting and its value to a stream.
+// It takes the name of the setting (varName) and a stream (stream) as arguments.
+// The macro writes the setting's display name (varName_disp), followed by a colon and the setting's value (varName).
+// It also adds a newline character at the end.
+#define SAVE_SETTING(varName, stream) stream << varName##_##disp << ":" << varName << "\n"
+
+Settings::Settings() {
+
+}
+
+Settings::~Settings() {
+
+}
+
+void Settings::Save() {
+	// Create the directories for the config file if they don't exist.
+	std::filesystem::create_directories(G_CONFIG_PATH);
+	// Open the settings file for writing.
+	std::ofstream file(GetSettingsFilePath());
+	// Check if the file was successfully opened.
+	if (file.is_open()) {
+		// Write the player's name setting to the file using the SAVE_SETTING macro.
+		SAVE_SETTING(m_playerName, file);
+	}
+}
+
+void Settings::Load() {
+	// Open the settings file for reading.
+	std::ifstream file(GetSettingsFilePath());
+
+	// Check if the file was successfully opened.
+	if (file.is_open()) {
+		// Read each line of the file.
+		std::string line;
+		while (std::getline(file, line)) {
+			// Split the line at the first colon character.
+			int split = line.find_first_of(":");
+
+			// Check if the line was successfully split.
+			if (split != std::string::npos) {
+				// Extract the setting's name and value from the line.
+				std::string settingName = line.substr(0, split);
+				std::string value = line.substr(split + 1);
+
+				// Check if the setting is the player's name.
+				if (settingName == m_playerName_disp) {
+					// Update the player's name with the value from the file.
+					m_playerName = value;
+				}
+				// You can add additional checks for other settings here using an else if clause.
+				// For example:
+				/*else if (settingName == m_otherSetting_disp) {
+					m_otherSetting = value;
+				}*/
+			}
+		}
+	}
+}
+
+const std::string& Settings::GetPlayerName() const {
+	return m_playerName;
+}
+
+void Settings::SetPlayerName(const std::string& name) {
+	m_playerName = name;
+}
+
+void Settings::SetPlayerName(const char* name) {
+	m_playerName = name;
+}
+
+std::filesystem::path Settings::GetSettingsFilePath() {
+	// Concatenate the directory path and file name to get the full path to the settings file.
+	auto path = G_CONFIG_PATH.string() + "/" + G_SETTINGS_FILENAME.string();
+	// Return the full path to the settings file.
+	return path;
+}

--- a/GameBox/GameBox/Settings.h
+++ b/GameBox/GameBox/Settings.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <string>
+#include <filesystem>
+
+// Directory where the settings file is stored.
+const std::filesystem::path G_CONFIG_PATH = "config";
+// Name of the settings file.
+const std::filesystem::path G_SETTINGS_FILENAME = "settings.txt";
+
+// SETTING_STRING macro is used to define a setting that stores a string value.
+// It takes three arguments:
+// 1. varName: the name of the setting variable. This argument should be the name you want to use for the variable that will store the value of the setting.
+// 2. displayName: the display name of the setting. This argument should be a string literal that will be used as the display name of the setting when it is saved or loaded from a file.
+// 3. defaultValue: the default value for the setting. This argument should be a string literal that will be used as the default value for the setting.
+// The macro defines two variables: a variable to store the value of the setting, and a variable to store the display name of the setting.
+// The value variable is a std::string and is initialized with the default value provided as an argument.
+// The display name variable is a const char* (a pointer to a constant character) and is initialized with the display name provided as an argument.
+#define SETTING_STRING(varName, displayName, defaultValue) std::string varName = defaultValue; \
+ const char* varName##_##disp = displayName;
+
+// SETTING_INT macro is used to define a setting that stores an int value.
+#define SETTING_INT(varName, displayName, defaultValue) int varName = defaultValue; \
+ const char* varName##_##disp = displayName;
+
+#define MAX_PLAYER_NAME_LENGTH 32
+
+// Settings class represents the game's settings and provides methods for saving and loading them from a file.
+class Settings {
+public:
+	Settings();
+	~Settings();
+	// Saves the current settings to a file.
+	void Save();
+	// Loads the settings from a file.
+	void Load();
+
+	// Returns the player's name.
+	const std::string& GetPlayerName() const;
+	// Sets the player's name.
+	void SetPlayerName(const std::string& name);
+	void SetPlayerName(const char* name);
+
+	// Returns the path to the settings file.
+	std::filesystem::path GetSettingsFilePath();
+
+private:
+	// Player's name setting.
+	SETTING_STRING(m_playerName, "PlayerName", "player"); //This might be an to overly complicated way of creating the two variables named m_playerName and m_playerName_disp. m_playerName get assigned "player" and m_playerName_disp will be assigned "PlayerName".
+};

--- a/GameBox/GameBox/Settings.h
+++ b/GameBox/GameBox/Settings.h
@@ -35,7 +35,7 @@ public:
 	void Load();
 
 	// Returns the player's name.
-	const std::string& GetPlayerName() const;
+	const std::string& GetPlayerName();
 	// Sets the player's name.
 	void SetPlayerName(const std::string& name);
 	void SetPlayerName(const char* name);
@@ -43,7 +43,8 @@ public:
 	// Returns the path to the settings file.
 	std::filesystem::path GetSettingsFilePath();
 
+	void RandomizePlayerName();
 private:
 	// Player's name setting.
-	SETTING_STRING(m_playerName, "PlayerName", "player"); //This might be an to overly complicated way of creating the two variables named m_playerName and m_playerName_disp. m_playerName get assigned "player" and m_playerName_disp will be assigned "PlayerName".
+	SETTING_STRING(m_playerName, "PlayerName", ""); //This might be an to overly complicated way of creating the two variables named m_playerName and m_playerName_disp. m_playerName get assigned "player" and m_playerName_disp will be assigned "PlayerName".
 };

--- a/GameBox/GameBox/state/GameState.cpp
+++ b/GameBox/GameBox/state/GameState.cpp
@@ -67,7 +67,7 @@ void GameState::handleWindowEvent(const sf::Event& windowEvent) {
 			m_game->SetState(States::MainMenu);
 		}
 		if (windowEvent.key.code == sf::Keyboard::Q) {
-			if (!systems.system<PickingSystem>().get()->getIsBlueprintActive()) 			{
+			if (!systems.system<PickingSystem>().get()->getIsBlueprintActive()) {
 				auto ent = entities.create();
 				auto spriteComp = ent.assign<sf::Sprite>().get();
 				spriteComp->setPosition(m_game->getWindow()->mapPixelToCoords(sf::Mouse::getPosition(*m_game->getWindow())));

--- a/GameBox/GameBox/state/MainMenuState.cpp
+++ b/GameBox/GameBox/state/MainMenuState.cpp
@@ -15,7 +15,7 @@ MainMenuState::MainMenuState(Game* pGame) : State(States::MainMenu, pGame) {
 	m_buttons.back().setPosition(posX, posY);
 	posY += 50;
 
-	m_buttons.push_back(Button("Settings (not implemented)", pGame->GetFont(), [&]() {printf("MainMenu: \"Settings\" Button Pressed!\n"); }));
+	m_buttons.push_back(Button("Settings", pGame->GetFont(), [&]() {printf("MainMenu: \"Settings\" Button Pressed!\n"); m_game->SetState(States::SettingsMenu);  }));
 	m_buttons.back().setPosition(posX, posY);
 	posY += 50;
 

--- a/GameBox/GameBox/state/SettingsMenuState.cpp
+++ b/GameBox/GameBox/state/SettingsMenuState.cpp
@@ -1,0 +1,59 @@
+//#define _CRT_SECURE_NO_WARNINGS - Allow std::strncpy to be used instead of std::strncpy_s 
+#define _CRT_SECURE_NO_WARNINGS
+#include "SettingsMenuState.h"
+#include "../Game.h"
+
+SettingsMenuState::SettingsMenuState(Game* pGame) : State(States::ID::SettingsMenu, pGame) {
+	// Get the player's name from the game's settings.
+	const std::string& pname = m_game->GetSettings().GetPlayerName();
+	// Copy the player's name to the player name buffer, with a maximum length of MAX_PLAYER_NAME_LENGTH - 1 characters.
+	std::strncpy(m_playerNameTemp, pname.c_str(), MAX_PLAYER_NAME_LENGTH - 1);
+	// Ensure that the player name buffer is null-terminated.
+	m_playerNameTemp[MAX_PLAYER_NAME_LENGTH - 1] = '\0';
+}
+
+SettingsMenuState::~SettingsMenuState() {
+}
+
+void SettingsMenuState::handleWindowEvent(const sf::Event& windowEvent) {
+	switch (windowEvent.type) {
+	case sf::Event::EventType::KeyPressed:
+		if (windowEvent.key.code == sf::Keyboard::Escape) {
+			m_game->SetState(States::MainMenu);
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+void SettingsMenuState::processInput(float dt) {
+}
+
+void SettingsMenuState::update(float dt) {
+}
+
+void SettingsMenuState::renderGUI(float dt) {
+	// Get the size of the game window.
+	sf::Vector2u windowSize = m_game->getWindow()->getSize();
+
+	// Set the size and position of the next ImGui window to fill the game window.
+	ImGui::SetNextWindowSize(ImVec2(windowSize.x, windowSize.y));
+	ImGui::SetNextWindowPos(ImVec2(0, 0));
+
+	// Begin a new ImGui window with the specified name, flag, and state.
+	if (ImGui::Begin("SettingsMenu", &m_settingMenuOpen, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings)) {
+		// Display an input field for the player's name.
+		// If the value in the field is changed, update the player's name in the game's settings.
+		if (ImGui::InputText("PlayerName", m_playerNameTemp, MAX_PLAYER_NAME_LENGTH - 1)) {
+			m_game->GetSettings().SetPlayerName(m_playerNameTemp);
+		}
+		// End the ImGui window.
+		ImGui::End();
+	}
+	// If the settings menu is closed, switch to the main menu state.
+	if (!m_settingMenuOpen) {
+		m_game->SetState(States::MainMenu);
+	}
+
+}

--- a/GameBox/GameBox/state/SettingsMenuState.h
+++ b/GameBox/GameBox/state/SettingsMenuState.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "State.h"
+#include "../Settings.h"
+
+class SettingsMenuState : public State {
+public:
+	SettingsMenuState(Game* pGame);
+	~SettingsMenuState();
+
+private:
+	// Inherited via State
+	virtual void handleWindowEvent(const sf::Event& windowEvent) override;
+
+	virtual void processInput(float dt) override;
+
+	virtual void update(float dt) override;
+
+	virtual void renderGUI(float dt) override;
+
+	char m_playerNameTemp[MAX_PLAYER_NAME_LENGTH] = {};
+	bool m_settingMenuOpen = true;
+};

--- a/GameBox/GameBox/state/State.cpp
+++ b/GameBox/GameBox/state/State.cpp
@@ -4,6 +4,9 @@
 State::State(States::ID id, Game* pGame) {
 	m_id = id;
 	m_game = pGame;
+
+	//Reset the view for each new state
+	m_game->getWindow()->setView(m_game->getWindow()->getDefaultView());
 }
 
 State::~State() {

--- a/GameBox/GameBox/state/State.h
+++ b/GameBox/GameBox/state/State.h
@@ -12,7 +12,8 @@ namespace States {
 	enum ID : char {
 		None,
 		MainMenu,
-		Game
+		Game,
+		SettingsMenu,
 	};
 }
 


### PR DESCRIPTION
New
- Added a SettingsClass stored inside Game.h that can store all user defined settings. This settings class can load/save settings from/to file.
- Added an gitIgnore rule for a folder called "config" where the game can store any autogenerated settings files.
- Added a new State called "SettingsMenuState" from where settings can be changed
- Changed c++ version from 14 to 17 in order to support "std::filesystem" 
- Added the define "_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING" to the preprocessor to avoid entityX throwing warnings after upgrading to c++17.

Bug Fixes
- https://github.com/Disco-Code/GameBox/issues/13 Fixed a bug causing the main menu not to render properly after entering the game once then going back to the menu. Issue fixed by resetting the window view for each new State. State.cpp:9.